### PR TITLE
Compile for kernel >= 5.17

### DIFF
--- a/smi_drv.c
+++ b/smi_drv.c
@@ -531,7 +531,11 @@ static struct drm_driver driver = {
 
 static int __init smi_init(void)
 {
-	if (vgacon_text_force() && smi_modeset == -1)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+        if (drm_firmware_drivers_only() && smi_modeset == -1)
+#else
+        if (vgacon_text_force() && smi_modeset == -1)
+#endif
 		return -EINVAL;
 
 	if (smi_modeset == 0)


### PR DESCRIPTION
The function `vgacon_text_force()` was replaced by `drm_firmware_drivers_only()` on commit https://github.com/torvalds/linux/commit/6a2d2ddf2c345e0149bfbffdddc4768a9ab0a741.

For kernels >= 5.17