### PR TITLE
Stop limiting bpp to 16 for SM750

### DIFF
--- a/smi_mode.c
+++ b/smi_mode.c
@@ -1158,9 +1158,6 @@ int smi_modeset_init(struct smi_device *cdev)
 	if(smi_bpp >= 24)
 		smi_bpp = 32;
 
-	if(cdev->specId == SPC_SM750)
-		smi_bpp = 16;
-
 #ifdef PRIME
 	smi_bpp = 32;
 #endif


### PR DESCRIPTION
At first glance sm750 seems to work well at 24bpp. Cannot find a rational for limiting the color depth. Therefore I'd propose to remove the limitation.