### PR TITLE
Include headers to fix build failure for implicit declaration

### DIFF
--- a/smi_debugfs.c
+++ b/smi_debugfs.c
@@ -5,6 +5,8 @@
 #include <drm/drm_print.h>
 #include "smi_drv.h"
 #include "ddk768/ddk768_pwm.h"
+#include <linux/vmalloc.h>
+#include <linux/debugfs.h>
 #include <drm/drm_debugfs.h>
 #include "smi_debugfs.h"
 


### PR DESCRIPTION
Closes: https://github.com/teddywlq/smifb2/issues/21