### PR TITLE
Support Linux 6.14

### DIFF
--- a/smi_drv.c
+++ b/smi_drv.c
@@ -556,7 +556,9 @@ static struct drm_driver driver = {
 	.fops = &smi_driver_fops,
 	.name = DRIVER_NAME,
 	.desc = DRIVER_DESC,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
 	.date = DRIVER_DATE,
+#endif
 	.major = DRIVER_MAJOR,
 	.minor = DRIVER_MINOR,
 	.patchlevel = DRIVER_PATCHLEVEL,

--- a/smi_drv.c
+++ b/smi_drv.c
@@ -30,7 +30,11 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 #include <linux/aperture.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+#include <drm/clients/drm_client_setup.h>
+#else
 #include <drm/drm_client_setup.h>
+#endif
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
 #include <drm/drm_aperture.h>
 #endif


### PR DESCRIPTION
Fix compile time errors in Linux 6.14 due to the following commits:
- cb2e1c2136f716 drm: remove driver date from struct drm_driver and all drivers
- b86711c6d6e20e drm/client: Move public client header to clients/ subdirectory