### PR TITLE
Fix build for kernel 6.17 to Kernel 7.0

### DIFF
--- a/smi_main.c
+++ b/smi_main.c
@@ -42,6 +42,9 @@ static int smi_user_framebuffer_dirty(struct drm_framebuffer *fb, struct drm_fil
 
 static struct drm_framebuffer *smi_user_framebuffer_create(struct drm_device *dev,
 							   struct drm_file *filp,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+							   const struct drm_format_info *drm_info,
+#endif
 							   const struct drm_mode_fb_cmd2 *mode_cmd);
 
 static const struct drm_framebuffer_funcs smi_fb_funcs = {
@@ -148,9 +151,11 @@ static int smi_handle_damage(struct drm_framebuffer *fb, struct drm_clip_rect cl
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
 	gbo = drm_gem_vram_of_gem(obj);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 	ret = drm_gem_vram_pin(gbo, DRM_GEM_VRAM_PL_FLAG_VRAM);
 	if (ret)
 		return (0);
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 	ret = drm_gem_vram_vmap(gbo, &dst_map);
@@ -232,7 +237,9 @@ static int smi_handle_damage(struct drm_framebuffer *fb, struct drm_clip_rect cl
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
 	if (kmap)		
 	{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 		drm_gem_vram_unpin(gbo);
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 		drm_gem_vram_vunmap(gbo, &dst_map);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
@@ -300,9 +307,16 @@ unlock:
 
 static struct drm_framebuffer *smi_user_framebuffer_create(struct drm_device *dev,
 							   struct drm_file *filp,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+								 const struct drm_format_info *drm_info,
+#endif
 							   const struct drm_mode_fb_cmd2 *mode_cmd)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+	return (drm_gem_fb_create_with_funcs(dev, filp, drm_info, mode_cmd, &smi_fb_funcs));
+#else
 	return (drm_gem_fb_create_with_funcs(dev, filp, mode_cmd, &smi_fb_funcs));
+#endif
 }
 
 /*

--- a/smi_plane.c
+++ b/smi_plane.c
@@ -135,15 +135,19 @@ static void smi_cursor_atomic_update(struct drm_plane *plane,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
 		gbo = drm_gem_vram_of_gem(fb->obj[0]);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 		if (drm_gem_vram_pin(gbo, DRM_GEM_VRAM_PL_FLAG_VRAM) < 0) {
 			dbg_msg("vram_pin failed\n");
 			LEAVE();
 		}
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0) */
 
 		cursor_offset = drm_gem_vram_offset(gbo);
 		if (cursor_offset < 0) {
 			dbg_msg("get gpu_addr failed\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 			drm_gem_vram_unpin(gbo);
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0) */
 			LEAVE();
 		}
 		if (sdev->specId == SPC_SM750) {
@@ -184,7 +188,9 @@ static void smi_cursor_atomic_update(struct drm_plane *plane,
 					  BPP32_BLUE);
 			ddk768_enableCursor(disp_ctrl, 3);
 		}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 		drm_gem_vram_unpin(gbo);
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0) */
 #else
 		bo = gem_to_smi_bo(fb->obj[0]);
 		if (smi_bo_pin(bo, TTM_PL_FLAG_VRAM, &cursor_offset) < 0) {
@@ -283,7 +289,7 @@ static const struct drm_plane_helper_funcs smi_cursor_helper_funcs = {
 	.atomic_disable = smi_cursor_atomic_disable,
 };
 
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 __attribute__((unused)) static int smi_primary_plane_prepare_fb(struct drm_plane *plane, struct drm_plane_state *new_state)
 {
 
@@ -363,6 +369,7 @@ __attribute__((unused)) static void smi_primary_plane_cleanup_fb(struct drm_plan
 	}
 	LEAVE();
 }
+#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0) */
 
 static void smi_primary_plane_atomic_update(struct drm_plane *plane,
 #if KERNEL_VERSION(5, 13, 0) >  LINUX_VERSION_CODE


### PR DESCRIPTION
I changed the code to be able to build the driver in kernel 6.17+

I compile-tested the code in kernel 6.17, 6.19 and kernel 7.0rc4..

root@ubuntu-resolute:/home/afaina/dkms/resolute/smifb2-dkms/upstream# dkms status
smifb2/2.4.1, 6.17.0-19-generic, x86_64: installed
smifb2/2.4.1, 6.19.0-9-generic, x86_64: installed
smifb2/2.4.1, 7.0.0-7-generic, x86_64: installed

Only tested in x86_64 architecture.

I cannot test the full working behavior, as I don't have an SM GPU.

Canonical LP bug: https://bugs.launchpad.net/ubuntu/+source/smifb2/+bug/2144583

Signed-off-by: Alessio Faina <alessio.faina@canonical.com>